### PR TITLE
Document the need of json-loader in webpack 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,19 @@ To use datalib in the browser, you need to build the datalib.js and datalib.min.
 
 1. Run `npm install` in the datalib folder to install dependencies.
 2. Run `npm run build`. This will invoke [browserify](http://browserify.org/) to bundle the source files into datalib.js, and then [uglify-js](http://lisperator.net/uglifyjs/) to create the minified datalib.min.js.
+
+
+### Webpack 1
+
+If you are using Webpack 1, you need to enable a JSON-loader. To do so, first `npm install --save json-loader`, then add the loader to your webpack config:
+
+```js
+{
+  module: {
+    loaders: [{
+      test: /\.json$/,
+      loader: 'json-loader'
+    }]
+  }
+}
+```


### PR DESCRIPTION
Since the merge of #81 datalib can't be bundle in webpack 1. 

The reason, the require of a JSON file is not supported by default, so the user has to use a json-loader. 

In webpack >= 2 should not be any issue since the JSON support is built inside the core.